### PR TITLE
viewer.js: prevent stylesheet update before reading Element#client* properties

### DIFF
--- a/YabumiUWP/app/js/viewer.js
+++ b/YabumiUWP/app/js/viewer.js
@@ -1139,11 +1139,15 @@
         }
 
         ratio = Math.max(Math.min(ratio, maxRatio), minRatio);
+        Viewer.Stat.zoom = ratio;
+
+        Viewer.Stat.panX = (Viewer.Stat.panX - dx) / oldRatio * ratio + dx;
+        Viewer.Stat.panY = (Viewer.Stat.panY - dy) / oldRatio * ratio + dy;
+
+        panImage();
 
         Viewer.View.image.style.width = (Viewer.Data.imageInfo.width * ratio) + 'px';
         Viewer.View.image.style.height = (Viewer.Data.imageInfo.height * ratio) + 'px';
-
-        Viewer.Stat.zoom = ratio;
 
         if (ratio === minRatio) {
             Viewer.Stat.zoomed = false;
@@ -1185,10 +1189,6 @@
             Viewer.View.expandButton.attr('title', _L('shortcut-fit-in-window'));
         }                                             
 
-        Viewer.Stat.panX = (Viewer.Stat.panX - dx) / oldRatio * ratio + dx;
-        Viewer.Stat.panY = (Viewer.Stat.panY - dy) / oldRatio * ratio + dy;
-
-        panImage();
     }
 
     function panImage(x, y) {


### PR DESCRIPTION
Stylesheetを更新してからElementのclient*とかにアクセスすると、スタイルの再計算が走ってしまうので、
これを避けるように変更しました。
https://yabumi.cc/1522a32a07bd489f2a653701.png

追伸
このPRは PR #2 とたぶんコンフリクトします。
